### PR TITLE
Fix loading with .from_pretrained() on transformers==4.34.1

### DIFF
--- a/mPLUG-Owl/mplug_owl/configuration_mplug_owl.py
+++ b/mPLUG-Owl/mplug_owl/configuration_mplug_owl.py
@@ -256,9 +256,9 @@ class MplugOwlConfig(PretrainedConfig):
         self.initializer_factor = 1.0
         self.initializer_range = 0.02
 
-        for attr in dir(self.text_config):
+        for attr, value in self.text_config.attribute_map.items():
             if not hasattr(self, attr):
-                setattr(self, attr, getattr(self.text_config, attr))
+                setattr(self, attr, value)
 
     @classmethod
     def from_vision_visual_abstractor_text_configs(


### PR DESCRIPTION
Currently, loading the mPLUG models using `.from_pretrained(...)` on `transformers==4.34.1` raises TypeError, complaining `_rope_scaling_validation` is not JSON serializable, as it is a method.

This pull request fixes this bug.

See also: https://github.com/X-PLUG/mPLUG-Owl/issues/132.
